### PR TITLE
bump since to 2020.3

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,27 @@
+name: Verify
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    name: Run Verify
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Run the Gradle package task
+        uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7
+        with:
+          arguments: runPluginVerifier

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,15 +7,15 @@ plugins {
 // TODO (TH) should be publisher company
 group = "org.jetbrains"
 
-version = "0.6.2"
+version = "1.0.0"
 
 repositories {
   mavenCentral()
 }
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_11
 }
 
 dependencies {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>io.wisetime.plugins.window.branch</id>
     <name>Branch in Window Title</name>
-    <version>0.6.2</version>
+    <version>1.0.0</version>
     <vendor>WiseTime</vendor>
 
     <description><![CDATA[
@@ -11,7 +11,7 @@
     ]]></description>
 
     <change-notes><![CDATA[
-      Version 0.6.2 - Support for custom frame decoration on Windows
+      Version 1.0.0 - Support for custom frame decoration on Windows
       Version 0.6.1 - Support IntelliJ IDEA 2020.1
       Version 0.6.0 - Improve stability with IntelliJ 2019.3.3+, Subversion support.<br>
       Version 0.5.5 - Improve logging output in event no git repository is located in project.<br>
@@ -22,7 +22,7 @@
     ]]>
     </change-notes>
 
-    <idea-version since-build="172.2103.15"/>
+    <idea-version since-build="203"/>
 
     <depends>com.intellij.modules.lang</depends>
     <depends optional="true" config-file="git-extension.xml">Git4Idea</depends>


### PR DESCRIPTION
Latest changes rely on new API. Therefore bumped since-version to 2020.3. Users with older IDE will receive previous release of plugin, users with newer IDE will receive this release of plugin.